### PR TITLE
fix bash script paths

### DIFF
--- a/test.sh
+++ b/test.sh
@@ -6,5 +6,5 @@ set -e
 cd ~/kotlin
 ./gradlew :kotlin-gradle-plugin:install --parallel
 
-cd /Users/sergey.rostov/IdeaProjects/kotlin-full-stack-application-demo
+cd - # back to previous dir (project dir)
 ./gradlew -Dorg.gradle.debug=true $@

--- a/watch.sh
+++ b/watch.sh
@@ -6,5 +6,5 @@ set -e
 cd ~/kotlin
 ./gradlew :kotlin-gradle-plugin:install --parallel
 
-cd /Users/jetbrains/IdeaProjects/kotlin-full-stack-application-demo
+cd - # back to previous dir (project dir)
 ./gradlew -Dorg.gradle.debug=true $@ --continuous


### PR DESCRIPTION
Раньше был указан абсолютный путь к директории в файловой системе.
Я воспользовался. командой
```bash
cd -
```
И тогда bash выставит предыдущую директорию